### PR TITLE
Fix compilation error

### DIFF
--- a/pbzx.c
+++ b/pbzx.c
@@ -34,7 +34,7 @@
 
 /* Structure to hold the command-line options. */
 struct options {
-    bool stdin;    /* True if data should be read from stdin. */
+    bool read_stdin;    /* True if data should be read from stdin. */
     bool noxar;    /* The input data is not a XAR archive but the pbzx Payload. */
     bool help;     /* Print usage with details and exit. */
     bool version;  /* Print version and exit. */
@@ -74,7 +74,7 @@ static void parse_args(int* argc, char const** argv, struct options* opts) {
         /* Skip arguments that are not flags. */
         if (argv[i][0] != '-') continue;
         /* Match available arguments. */
-        if      (strcmp(argv[i], "-")  == 0) opts->stdin = true;
+        if      (strcmp(argv[i], "-")  == 0) opts->read_stdin = true;
         else if (strcmp(argv[i], "-n") == 0) opts->noxar = true;
         else if (strcmp(argv[i], "-h") == 0) opts->help = true;
         else if (strcmp(argv[i], "-v") == 0) opts->version = true;
@@ -204,9 +204,9 @@ int main(int argc, const char** argv) {
     parse_args(&argc, argv, &opts);
     if (opts.version) version();
     if (opts.help) usage(NULL);
-    if (!opts.stdin && argc < 2)
+    if (!opts.read_stdin && argc < 2)
         usage("missing filename argument");
-    else if ((!opts.stdin && argc > 2) || (opts.stdin && argc > 1))
+    else if ((!opts.read_stdin && argc > 2) || (opts.read_stdin && argc > 1))
         usage("unhandled positional argument(s)");
 
     char const* filename = NULL;
@@ -216,7 +216,7 @@ int main(int argc, const char** argv) {
     struct stream stream;
     stream_init(&stream);
     bool success = false;
-    if (opts.stdin) {
+    if (opts.read_stdin) {
         stream.type = STREAM_FP;
         stream.fp = stdin;
         success = true;
@@ -291,6 +291,6 @@ int main(int argc, const char** argv) {
     }
     free(zbuf);
     lzma_end(&zs);
-    if (!opts.stdin) stream_close(&stream);
+    if (!opts.read_stdin) stream_close(&stream);
     return 0;
 }

--- a/tests/test_pbzx.c
+++ b/tests/test_pbzx.c
@@ -185,7 +185,7 @@ TEST test_parse_args_no_flags(void) {
     int argc = 2;
     struct options opts = {0};
     parse_args(argc, argv, &opts);
-    ASSERT_FALSE(opts.stdin);
+    ASSERT_FALSE(opts.read_stdin);
     ASSERT_FALSE(opts.noxar);
     ASSERT_FALSE(opts.help);
     ASSERT_FALSE(opts.version);
@@ -198,7 +198,7 @@ TEST test_parse_args_stdin_flag(void) {
     int argc = 2;
     struct options opts = {0};
     parse_args(argc, argv, &opts);
-    ASSERT(opts.stdin);
+    ASSERT(opts.read_stdin);
     ASSERT_EQ(NULL, opts.filename);
     PASS();
 }
@@ -219,7 +219,7 @@ TEST test_parse_args_multiple_flags(void) {
     struct options opts = {0};
     parse_args(argc, argv, &opts);
     ASSERT(opts.noxar);
-    ASSERT(opts.stdin);
+    ASSERT(opts.read_stdin);
     ASSERT_EQ(NULL, opts.filename);
     PASS();
 }


### PR DESCRIPTION
I was compiling pbzx on GNU/Linux, using Clang 21 and/or GCC 15:
```
pbzx.c:77:52: error: expected identifier
   77 |         if      (strcmp(argv[i], "-")  == 0) opts->stdin = true;
      |                                                    ^
/usr/include/stdio.h:66:16: note: expanded from macro 'stdin'
   66 | #define stdin  (stdin)
      |                ^
```
`stdin` is expanded as a standard macro, causing compilation to fail.

This PR changes `option::stdin` to `option::read_stdin`.

PS: Besides this fix, I had to link in additional libraries, via `-lxar -lbz2 -lxml2 -lssl -lcrypto -lz -llzma`.

Edit: The additional link libraries were due to me linking static libraries. For dynamic libraries these are not required.