### PR TITLE
Fix fread return value in stream_read for STREAM_FP

### DIFF
--- a/pbzx.c
+++ b/pbzx.c
@@ -178,7 +178,7 @@ static uint32_t stream_read(char* buf, uint32_t size, struct stream* s) {
             }
             return size;
         case STREAM_FP:
-            return fread(buf, size, 1, s->fp);
+            return fread(buf, 1, size, s->fp);
     }
     abort();
 }

--- a/tests/test_pbzx.c
+++ b/tests/test_pbzx.c
@@ -109,13 +109,7 @@ TEST test_stream_read_null_stream(void) {
     PASS();
 }
 
-TEST test_stream_read_fp_returns_item_count(void) {
-    /*
-     * Known issue: stream_read for STREAM_FP calls fread(buf, size, 1, fp)
-     * which returns the number of items (0 or 1), NOT the number of bytes.
-     * The XAR path returns byte count. This inconsistency is latent because
-     * main() never checks the return value of stream_read.
-     */
+TEST test_stream_read_fp_returns_byte_count(void) {
     char tmppath[] = "/tmp/pbzx_test_read_XXXXXX";
     int fd = mkstemp(tmppath);
     ASSERT(fd >= 0);
@@ -127,8 +121,7 @@ TEST test_stream_read_fp_returns_item_count(void) {
 
     char buf[8] = {0};
     uint32_t ret = stream_read(buf, 8, &s);
-    /* Returns 1 (one item of size 8), not 8 (bytes read) */
-    ASSERT_EQ(1, ret);
+    ASSERT_EQ(8, ret);
     ASSERT_MEM_EQ("ABCDEFGH", buf, 8);
 
     stream_close(&s);
@@ -138,7 +131,7 @@ TEST test_stream_read_fp_returns_item_count(void) {
 
 SUITE(suite_stream_read) {
     RUN_TEST(test_stream_read_null_stream);
-    RUN_TEST(test_stream_read_fp_returns_item_count);
+    RUN_TEST(test_stream_read_fp_returns_byte_count);
 }
 
 /* ========== stream_read_64() tests ========== */


### PR DESCRIPTION
## Summary

`stream_read` is documented to return the number of bytes read into the buffer. The `STREAM_XAR` code path correctly returns a byte count, but the `STREAM_FP` path called `fread(buf, size, 1, fp)` — which reads **1 item** of `size` bytes and returns the number of **items** read (0 or 1), not the number of bytes.

This means any caller checking the return value of `stream_read` on a file-backed stream would see `1` instead of the actual byte count (e.g. `8`), which could cause silent data loss or incorrect offset calculations. The bug was latent because `main()` currently doesn't check the return value, but any future use of it would hit this inconsistency.

The fix swaps the arguments to `fread(buf, 1, size, fp)`, which reads up to `size` individual bytes and returns the actual number of bytes read.

## Test plan
- [x] All 16 unit tests pass
- [x] All 19 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)