### PR TITLE
Fix parse_args() not parsing flags correctly when combined

### DIFF
--- a/pbzx.c
+++ b/pbzx.c
@@ -38,12 +38,13 @@ struct options {
     bool noxar;    /* The input data is not a XAR archive but the pbzx Payload. */
     bool help;     /* Print usage with details and exit. */
     bool version;  /* Print version and exit. */
+    const char* filename;  /* Positional filename argument. */
 };
 
 /* Prints usage information and exit. Optionally, displays an error message and
  * exits with an error code. */
 static void usage(char const* error) {
-    fprintf(stderr, "usage: pbzx [-v] [-h] [-n] [-] [filename]\n");
+    fprintf(stderr, "usage: pbzx [-v] [-h] [-n] <-|filename>\n");
     if (error) {
         fprintf(stderr, "error: %s\n", error);
         exit(EINVAL);
@@ -67,24 +68,21 @@ static void version() {
     exit(0);
 }
 
-/* Parses command-line flags into the #options structure and adjusts the
- * argument count and values on the fly to remain only positional arguments. */
+/* Parses command-line flags into the #options structure. */
 static void parse_args(int* argc, char const** argv, struct options* opts) {
-    for (int i = 0; i < *argc; ++i) {
-        /* Skip arguments that are not flags. */
-        if (argv[i][0] != '-') continue;
-        /* Match available arguments. */
-        if      (strcmp(argv[i], "-")  == 0) opts->stdin = true;
+    opts->filename = NULL;
+    for (int i = 1; i < *argc; ++i) {
+        if (argv[i][0] != '-') {
+            if (opts->filename) usage("unhandled positional argument(s)");
+            opts->filename = argv[i];
+        }
+        else if (strcmp(argv[i], "-")  == 0) opts->stdin = true;
         else if (strcmp(argv[i], "-n") == 0) opts->noxar = true;
         else if (strcmp(argv[i], "-h") == 0) opts->help = true;
         else if (strcmp(argv[i], "-v") == 0) opts->version = true;
         else usage("unrecognized flag");
-        /* Move all remaining arguments to the front. */
-        for (int j = 0; j < (*argc-1); ++j) {
-            argv[j] = argv[j+1];
-        }
-        (*argc)--;
     }
+    if (opts->stdin && opts->filename) usage("unhandled positional argument(s)");
 }
 
 static inline uint32_t min(uint32_t a, uint32_t b) {
@@ -205,13 +203,10 @@ int main(int argc, const char** argv) {
     parse_args(&argc, argv, &opts);
     if (opts.version) version();
     if (opts.help) usage(NULL);
-    if (!opts.stdin && argc < 2)
+    if (!opts.stdin && !opts.filename)
         usage("missing filename argument");
-    else if ((!opts.stdin && argc > 2) || (opts.stdin && argc > 1))
-        usage("unhandled positional argument(s)");
 
-    char const* filename = NULL;
-    if (argc >= 2) filename = argv[1];
+    char const* filename = opts.filename;
 
     /* Open a stream to the payload. */
     struct stream stream;

--- a/pbzx.c
+++ b/pbzx.c
@@ -69,9 +69,9 @@ static void version() {
 }
 
 /* Parses command-line flags into the #options structure. */
-static void parse_args(int* argc, char const** argv, struct options* opts) {
-    opts->filename = NULL;
-    for (int i = 1; i < *argc; ++i) {
+static void parse_args(int argc, char const** argv, struct options* opts) {
+    *opts = (struct options){0};
+    for (int i = 1; i < argc; ++i) {
         if (argv[i][0] != '-') {
             if (opts->filename) usage("unhandled positional argument(s)");
             opts->filename = argv[i];
@@ -200,7 +200,7 @@ static inline size_t cpio_out(char *buffer, size_t size) {
 int main(int argc, const char** argv) {
     /* Parse and validate command-line flags and arguments. */
     struct options opts = {0};
-    parse_args(&argc, argv, &opts);
+    parse_args(argc, argv, &opts);
     if (opts.version) version();
     if (opts.help) usage(NULL);
     if (!opts.stdin && !opts.filename)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -187,8 +187,7 @@ else
     fail "D7: empty payload" "non-zero exit"
 fi
 
-# D8: Stream via stdin (using just "-" flag; "-n -" doesn't work due to
-# parse_args multi-flag bug -- only the first flag gets processed)
+# D8: Stream via stdin
 if stdout=$(cat "$FIXTURES/valid_single_lzma.pbzx" | "$PBZX" - 2>/dev/null); then
     expected=$(cat "$FIXTURES/valid_single_lzma.expected")
     if [ "$stdout" = "$expected" ]; then
@@ -223,6 +222,18 @@ if "$PBZX" -n "$FIXTURES/large_chunk.pbzx" 2>/dev/null | shasum -a 256 > "$TMPDI
     fi
 else
     fail "D10: large chunk" "non-zero exit"
+fi
+
+# D11: Stream via stdin with -n flag (noxar + stdin combined)
+if stdout=$(cat "$FIXTURES/valid_single_lzma.pbzx" | "$PBZX" -n - 2>/dev/null); then
+    expected=$(cat "$FIXTURES/valid_single_lzma.expected")
+    if [ "$stdout" = "$expected" ]; then
+        pass "D11: stdin with -n flag"
+    else
+        fail "D11: stdin with -n flag" "output mismatch"
+    fi
+else
+    fail "D11: stdin with -n flag" "non-zero exit"
 fi
 
 # ========== E. Error Handling ==========

--- a/tests/test_pbzx.c
+++ b/tests/test_pbzx.c
@@ -189,8 +189,7 @@ TEST test_parse_args_no_flags(void) {
     ASSERT_FALSE(opts.noxar);
     ASSERT_FALSE(opts.help);
     ASSERT_FALSE(opts.version);
-    ASSERT_EQ(2, argc);
-    ASSERT_STR_EQ("file.pkg", argv[1]);
+    ASSERT_STR_EQ("file.pkg", opts.filename);
     PASS();
 }
 
@@ -200,7 +199,7 @@ TEST test_parse_args_stdin_flag(void) {
     struct options opts = {0};
     parse_args(&argc, argv, &opts);
     ASSERT(opts.stdin);
-    ASSERT_EQ(1, argc);
+    ASSERT_EQ(NULL, opts.filename);
     PASS();
 }
 
@@ -210,29 +209,18 @@ TEST test_parse_args_noxar_flag(void) {
     struct options opts = {0};
     parse_args(&argc, argv, &opts);
     ASSERT(opts.noxar);
-    ASSERT_EQ(2, argc);
-    ASSERT_STR_EQ("file.bin", argv[1]);
+    ASSERT_STR_EQ("file.bin", opts.filename);
     PASS();
 }
 
 TEST test_parse_args_multiple_flags(void) {
-    /*
-     * Known issue: parse_args has a bug in its shift logic -- it always
-     * shifts from j=0 instead of j=i, removing argv[0] instead of the
-     * matched flag. Combined with the loop increment, this means only
-     * the first flag after the program name actually gets processed
-     * when multiple flags are passed (e.g. "pbzx -n -").
-     *
-     * This test documents the current (buggy) behavior.
-     */
     const char* argv[] = {"pbzx", "-n", "-", NULL};
     int argc = 3;
     struct options opts = {0};
     parse_args(&argc, argv, &opts);
     ASSERT(opts.noxar);
-    /* Bug: "-" flag is NOT processed due to shift logic */
-    ASSERT_FALSE(opts.stdin);
-    ASSERT_EQ(2, argc);
+    ASSERT(opts.stdin);
+    ASSERT_EQ(NULL, opts.filename);
     PASS();
 }
 

--- a/tests/test_pbzx.c
+++ b/tests/test_pbzx.c
@@ -184,7 +184,7 @@ TEST test_parse_args_no_flags(void) {
     const char* argv[] = {"pbzx", "file.pkg"};
     int argc = 2;
     struct options opts = {0};
-    parse_args(&argc, argv, &opts);
+    parse_args(argc, argv, &opts);
     ASSERT_FALSE(opts.stdin);
     ASSERT_FALSE(opts.noxar);
     ASSERT_FALSE(opts.help);
@@ -197,7 +197,7 @@ TEST test_parse_args_stdin_flag(void) {
     const char* argv[] = {"pbzx", "-", NULL};
     int argc = 2;
     struct options opts = {0};
-    parse_args(&argc, argv, &opts);
+    parse_args(argc, argv, &opts);
     ASSERT(opts.stdin);
     ASSERT_EQ(NULL, opts.filename);
     PASS();
@@ -207,7 +207,7 @@ TEST test_parse_args_noxar_flag(void) {
     const char* argv[] = {"pbzx", "-n", "file.bin", NULL};
     int argc = 3;
     struct options opts = {0};
-    parse_args(&argc, argv, &opts);
+    parse_args(argc, argv, &opts);
     ASSERT(opts.noxar);
     ASSERT_STR_EQ("file.bin", opts.filename);
     PASS();
@@ -217,7 +217,7 @@ TEST test_parse_args_multiple_flags(void) {
     const char* argv[] = {"pbzx", "-n", "-", NULL};
     int argc = 3;
     struct options opts = {0};
-    parse_args(&argc, argv, &opts);
+    parse_args(argc, argv, &opts);
     ASSERT(opts.noxar);
     ASSERT(opts.stdin);
     ASSERT_EQ(NULL, opts.filename);


### PR DESCRIPTION
## Summary
- Fix broken argument shifting logic in `parse_args()` that caused consecutive flags to be skipped (e.g., `pbzx -n -` would skip the `-` flag and error with "failed to open: -")
- Replace shift-based argv manipulation with a simpler approach that stores the positional filename directly in the `options` struct
- Update tests to verify correct behavior (multiple flags now work) instead of documenting the bug

Fixes #2

## Test plan
- [x] All 16 unit tests pass
- [x] All 19 integration tests pass
- [x] `pbzx -n -` correctly sets both `noxar` and `stdin` flags
- [x] Extra positional arguments are still rejected
- [x] `stdin + filename` combination is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)