### PR TITLE
Add release CI workflow for pre-built binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,13 @@ jobs:
         include:
           - runner: macos-latest
             arch: arm64
+            deployment_target: '11.0'
           - runner: macos-13
             arch: x86_64
+            deployment_target: '10.13'
     runs-on: ${{ matrix.runner }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,10 +31,18 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Build release binary
+      - name: Build release binary (static liblzma)
         run: |
           make clean
-          make
+          make LIBS="$(brew --prefix)/lib/liblzma.a -lxar"
+
+      - name: Verify no Homebrew dylibs linked
+        run: |
+          otool -L pbzx
+          if otool -L pbzx | grep -q '/opt/homebrew\|/usr/local/opt'; then
+            echo "ERROR: Binary links against Homebrew dylibs"
+            exit 1
+          fi
 
       - name: Rename binary
         run: mv pbzx pbzx-darwin-${{ matrix.arch }}
@@ -50,13 +62,22 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x pbzx-darwin-*
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            pbzx-darwin-arm64 \
-            pbzx-darwin-x86_64
+          tag="${{ github.ref_name }}"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" \
+              --clobber \
+              pbzx-darwin-arm64 \
+              pbzx-darwin-x86_64
+          else
+            gh release create "$tag" \
+              --title "$tag" \
+              --generate-notes \
+              pbzx-darwin-arm64 \
+              pbzx-darwin-x86_64
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-13
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install xz
+
+      - name: Run tests
+        run: make test
+
+      - name: Build release binary
+        run: |
+          make clean
+          make
+
+      - name: Rename binary
+        run: mv pbzx pbzx-darwin-${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pbzx-darwin-${{ matrix.arch }}
+          path: pbzx-darwin-${{ matrix.arch }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          chmod +x pbzx-darwin-*
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            pbzx-darwin-arm64 \
+            pbzx-darwin-x86_64


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow triggered on tag push (`v*`) that builds `pbzx` for macOS arm64 and x86_64
- Runs the full test suite on each architecture before building the release binary
- Creates a GitHub Release with auto-generated notes and both binaries attached (`pbzx-darwin-arm64`, `pbzx-darwin-x86_64`)

Closes #1

## Test plan
- [ ] Merge this PR
- [ ] Create and push a tag: `git tag v1.0.3 && git push --tags`
- [ ] Verify the workflow runs successfully in GitHub Actions
- [ ] Verify the release page has both binaries attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)