### PR TITLE
Remove incorrect Homebrew installation claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ To compile `pbzx`, do
   [source]: http://www.tonymacx86.com/general-help/135458-pbzx-stream-parser.html
   [Homebrew]: http://brew.sh/
 
-## Install via Homebrew
-
-You can install `pbzx` via Homebrew now!
-
-    $ brew install pbzx
-
 ## Changelog
 
 __v1.0.2__


### PR DESCRIPTION
## Summary
- Removes the "Install via Homebrew" section from the README, which claimed `brew install pbzx` works
- No such Homebrew formula exists, so the section was misleading users

## Test plan
- [x] Verify the README renders correctly without the removed section

🤖 Generated with [Claude Code](https://claude.com/claude-code)